### PR TITLE
fix bug for .usa-header versus logo height at breakpoints

### DIFF
--- a/_sass/uswds/components/_header.scss
+++ b/_sass/uswds/components/_header.scss
@@ -13,9 +13,11 @@ $z-index-nav:     9000;
 .usa-header {
   width: 100%;
   z-index: $z-index-header;
+  min-height: 6.5rem;
 
   @include media($nav-width) {
     border-bottom: 1px solid $color-gray-lighter;
+    min-height: auto;
   }
 
   a {


### PR DESCRIPTION
On smaller screens the main content wasn't clearing the logo on the left because it was taller than the containing element. This just adds a min-height that corresponds to the height of the logo.

<3