### PR TITLE
Reduce risk by iterating and learning from best-in-class CSPs

### DIFF
--- a/pages/strategy.md
+++ b/pages/strategy.md
@@ -221,12 +221,16 @@ contracts to acquire them.
 
 Agencies should review their information technology portfolios to
 determine modernization plans for existing tools. They are encouraged to
-perform and leverage a full system and application rationalization, and
-those that have not begun this process are encouraged to start
-immediately. As part of this effort, agencies should consider whether
-virtualization, containerization, and other modern practices can be
-leveraged to increase efficiency in agency-owned data centers and vendor
-offerings. In accordance with the Federal Information Technology
+initiate a system and application rationalization process, and begin migrating key
+applications to a commercial cloud using virtualization, containerization,
+or other modern practices as soon as possible. The lessons learned from
+these early migrations will inform how to fully migrate and rationalize
+the entire portfolio. Agency staff should become familiar with using
+lean product management, agile development, continuous delivery, and
+automated infrastructure at the team and program level before committing
+to any long-term plan relying on government-owned data centers. Migrating
+iteratively will reduce risk of large-scale failure and mis-allocation of 
+resources. In accordance with the Federal Information Technology
 Acquisition Reform Act (FITARA),[^1] this process should be overseen by
 the Chief Information Officer (CIO) at the agency level to help identify
 potential opportunities for enterprise-wide improvement.


### PR DESCRIPTION
Original wording implied that cloud migration should not start until _after_ an application rationalization process.  Cloud adoption does not need to gated in that way. An agency will learn about how to use a cloud only by moving to a cloud. Use of cloud automation tools or higher level abstractions (e.g. PaaS or FaaS) will make such work portable to other CSPs, and de-risk the entire endeavor.

Moving to agency-owned and -operated data centers is a last resort, as few, if any,  such data centers provide cloud as defined by NIST from an end-user perspective.